### PR TITLE
Add route to trigger OpenSky auth task

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,3 +46,10 @@ async def health():
         pass
 
     return {"ok": all(status.values()), "services": status}
+
+
+@app.post("/auth")
+async def manual_auth():
+    """Manually trigger the OpenSky authentication task."""
+    task = opensky_auth.delay()
+    return {"task_id": task.id}


### PR DESCRIPTION
## Summary
- add `/auth` endpoint to launch `opensky_auth` task via Celery

## Testing
- `python -m py_compile backend/app/main.py backend/app/tasks.py backend/app/celery_app.py backend/app/config.py`

------
https://chatgpt.com/codex/tasks/task_e_687d1a220b8083259c88a4ef7f4f07be