### PR TITLE
Add APScheduler to refresh OpenSky token

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ pymongo
 httpx
 pydantic
 pydantic-settings
+apscheduler


### PR DESCRIPTION
## Summary
- run OpenSky token retrieval at FastAPI startup
- schedule the `opensky_auth` Celery task every 29 minutes using APScheduler
- add APScheduler dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687d23603c4483258d44a2ab730e335a