### PR TITLE
Fix callsigns upsert conflict

### DIFF
--- a/backend/app/service/opensky_store_datas.py
+++ b/backend/app/service/opensky_store_datas.py
@@ -34,7 +34,6 @@ def store_opensky_datas(states: list[dict]) -> None:
             },
             "$setOnInsert": {
                 "first_seen": request_time,
-                "callsigns": [],
             },
         }
         callsign = state.get("callsign")


### PR DESCRIPTION
## Summary
- when storing OpenSky data, don't set `callsigns` on insert

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687d3da2f4e483258701927642cc2f07