### PR TITLE
Trim trailing spaces in callsigns

### DIFF
--- a/backend/app/service/opensky_get_datas.py
+++ b/backend/app/service/opensky_get_datas.py
@@ -49,6 +49,9 @@ def get_opensky_datas() -> list[dict] | None:
 
     def process(state: list) -> dict:
         entry = dict(zip(keys, state))
+        callsign = entry.get("callsign")
+        if isinstance(callsign, str):
+            entry["callsign"] = callsign.strip()
         entry["request_time"] = request_time
         return entry
 

--- a/backend/app/service/opensky_store_datas.py
+++ b/backend/app/service/opensky_store_datas.py
@@ -37,6 +37,9 @@ def store_opensky_datas(states: list[dict]) -> None:
             },
         }
         callsign = state.get("callsign")
+        if isinstance(callsign, str):
+            callsign = callsign.strip()
+            state["callsign"] = callsign
         if callsign:
             update.setdefault("$addToSet", {})["callsigns"] = callsign
             update["$set"]["last_known_callsign"] = callsign

--- a/mongo-init/init-collections.js
+++ b/mongo-init/init-collections.js
@@ -21,6 +21,10 @@ for (var i = 0; i < collections.length; i++) {
 
 // Indexes to optimize queries and enforce uniqueness
 mydb.LIVE_STATES.createIndex({ icao24: 1 }, { unique: true });
+mydb.LIVE_STATES.createIndex({ request_time: 1 });
+mydb.HISTORICAL_STATES.createIndex({ icao24: 1, request_time: 1 });
+mydb.USERS.createIndex({ username: 1 }, { unique: true });
+mydb.TOKENS.createIndex({ name: 1 }, { unique: true });
 
 var users = [
   {


### PR DESCRIPTION
## Summary
- normalize callsign field by stripping whitespace during data retrieval
- ensure trimmed callsigns are stored in MongoDB
- index Mongo collections for faster lookups

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r backend/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_687d450b0b048325963b5d777247b544